### PR TITLE
fix: Add aws/account to the metadata

### DIFF
--- a/cmd/ctrlc/root/sync/aws/eks/eks.go
+++ b/cmd/ctrlc/root/sync/aws/eks/eks.go
@@ -156,7 +156,6 @@ func processClusters(ctx context.Context, eksClient *eks.Client, region string, 
 	var resources []api.AgentResource
 	var nextToken *string
 
-	// Get account ID using the passed config
 	accountID, err := common.GetAccountID(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get AWS account ID: %w", err)

--- a/cmd/ctrlc/root/sync/aws/eks/eks.go
+++ b/cmd/ctrlc/root/sync/aws/eks/eks.go
@@ -192,13 +192,15 @@ func processClusters(ctx context.Context, eksClient *eks.Client, region string) 
 
 func processCluster(_ context.Context, cluster *types.Cluster, region string) (api.AgentResource, error) {
 	metadata := initClusterMetadata(cluster, region)
+	
+	arnParts := strings.Split(*cluster.Arn, ":")
+	accountId := arnParts[4]
+	metadata["aws/account"] = accountId
 
 	consoleUrl := fmt.Sprintf("https://%s.console.aws.amazon.com/eks/home?region=%s#/clusters/%s",
 		region, region, *cluster.Name)
 	metadata["ctrlplane/links"] = fmt.Sprintf("{ \"AWS Console\": \"%s\" }", consoleUrl)
 
-	arnParts := strings.Split(*cluster.Arn, ":")
-	accountId := arnParts[4]
 
 	return api.AgentResource{
 		Version:    "ctrlplane.dev/kubernetes/cluster/v1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AWS account ID is now included in cluster metadata for improved visibility.  
  - Enhanced reliability in retrieving AWS account ID during EKS synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->