### PR TITLE
feat: create relationship between parent cluster and vclusters

### DIFF
--- a/internal/api/resource_provider.go
+++ b/internal/api/resource_provider.go
@@ -71,6 +71,10 @@ func (r *ResourceProvider) AddResourceRelationshipRule(ctx context.Context, rule
 	for _, rule := range rules {
 		rule.WorkspaceId = r.workspaceId
 		resp, err := r.client.CreateResourceRelationshipRuleWithResponse(ctx, rule)
+		if resp.StatusCode() == http.StatusConflict {
+			log.Info("Resource relationship rule already exists, skipped creation")
+			return nil
+		}
 		if err != nil {
 			return err
 		}
@@ -78,5 +82,6 @@ func (r *ResourceProvider) AddResourceRelationshipRule(ctx context.Context, rule
 			return fmt.Errorf("failed to upsert resource relationship rule: %s", string(resp.Body))
 		}
 	}
+	log.Info("Successfully created resource relationship rules")
 	return nil
 }

--- a/internal/kinds/db.go
+++ b/internal/kinds/db.go
@@ -74,6 +74,18 @@ const (
 )
 
 const (
+	GoogleMetadataSelfLink = "google/self-link"
+)
+
+const (
+	AWSMetadataARN = "aws/arn"
+)
+
+const (
+	AzureMetadataId = "azure/id"
+)
+
+const (
 	VClusterMetadataVersion      = "vcluster/version"
 	VClusterMetadataVersionMajor = "vcluster/version-major"
 	VClusterMetadataVersionMinor = "vcluster/version-minor"
@@ -82,4 +94,11 @@ const (
 	VClusterMetadataNamespace    = "vcluster/namespace"
 	VClusterMetadataStatus       = "vcluster/status"
 	VClusterMetadataCreated      = "vcluster/created"
+)
+
+const (
+	KindAmazonElasticKubernetesService = "AmazonElasticKubernetesService"
+	KindGoogleKubernetesEngine         = "GoogleKubernetesEngine"
+	KindAzureKubernetesService         = "AzureKubernetesService"
+	KindVCluster                       = "VCluster"
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added automatic creation of resource relationship rules linking vcluster resources to their parent clusters for supported cloud providers.
- **Improvements**
	- Enhanced handling of existing resource relationship rules to avoid errors when rules already exist.
	- Improved logging for resource synchronization and relationship rule creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->