### PR TITLE
feat: cache download of cli in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
         echo "BINARY_NAME: $BINARY_NAME"
 
         if [ "${{ inputs.version }}" = "latest" ]; then
-          VERSION=$(curl -s https://api.github.com/repos/${{ inputs.repo }}/releases/latest | jq -r .tag_name)
+          VERSION=$(curl -sfSL https://api.github.com/repos/${{ inputs.repo }}/releases/latest | jq -e -r .tag_name)
         else
           VERSION=${{ inputs.version }}
         fi
@@ -53,7 +53,7 @@ runs:
         DOWNLOAD_URL="https://github.com/${{ inputs.repo }}/releases/download/${VERSION}/$BINARY_NAME.tar.gz"
         echo "DOWNLOAD_URL: $DOWNLOAD_URL"
 
-        curl -L $DOWNLOAD_URL -o binary.tar.gz
+        curl -fSL $DOWNLOAD_URL -o binary.tar.gz
         tar xzf binary.tar.gz
         chmod +x ctrlc
         sudo mv ctrlc /usr/local/bin/

--- a/action.yml
+++ b/action.yml
@@ -25,12 +25,14 @@ runs:
   steps:
     - name: Cache CLI binary
       if: inputs.version != 'latest'
+      id: cache-cli
       uses: actions/cache@v4
       with:
         path: "/usr/local/bin/ctrlc"
         key: "ctrlplane-cli-${{ inputs.repo }}-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}"
 
     - name: Download binary
+      if: steps.cache-cli.outputs.cache-hit != 'true'
       shell: bash
       run: |
         OS=$(uname -s)

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Cache CLI binary
+      if: inputs.version != 'latest'
+      uses: actions/cache@v4
+      with:
+        path: "/usr/local/bin/ctrlc"
+        key: "ctrlplane-cli-${{ inputs.repo }}-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}"
+
     - name: Download binary
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -28,13 +28,15 @@ runs:
       id: cache-cli
       uses: actions/cache@v4
       with:
-        path: "/usr/local/bin/ctrlc"
+        path: "${{ runner.tool_cache }}/ctrlc/${{ inputs.version }}"
         key: "ctrlplane-cli-${{ inputs.repo }}-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}"
 
     - name: Download binary
       if: steps.cache-cli.outputs.cache-hit != 'true'
       shell: bash
       run: |
+        set -u # bail when referencing unset variables
+
         OS=$(uname -s)
         ARCH=$(uname -m)
         if [ "$ARCH" = "x86_64" ]; then
@@ -52,13 +54,21 @@ runs:
           VERSION=${{ inputs.version }}
         fi
 
-        DOWNLOAD_URL="https://github.com/${{ inputs.repo }}/releases/download/${VERSION}/$BINARY_NAME.tar.gz"
+        DOWNLOAD_URL="https://github.com/${{ inputs.repo }}/releases/download/${VERSION}/${BINARY_NAME}.tar.gz"
         echo "DOWNLOAD_URL: $DOWNLOAD_URL"
 
-        curl -fSL $DOWNLOAD_URL -o binary.tar.gz
+        curl -sfSL "${DOWNLOAD_URL}" -o binary.tar.gz
         tar xzf binary.tar.gz
         chmod +x ctrlc
-        sudo mv ctrlc /usr/local/bin/
+
+        cache_dir="${{ runner.tool_cache }}/ctrlc/${{ inputs.version }}"
+        mkdir -p "${cache_dir}"
+        mv ctrlc "${cache_dir}"
+
+    - name: Add ctrlc to path
+      shell: bash
+      run: |
+        echo "${{ runner.tool_cache }}/ctrlc/${{ inputs.version }}" >> "${GITHUB_PATH}"
 
     - name: Set Ctrlplane URL
       shell: bash


### PR DESCRIPTION
Cache the downloaded ctrlc binary so it's not retrieved on every run.  This buffers against possible failures when retrieving the binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced caching for the CLI binary to reduce redundant downloads for fixed versions.

- **Bug Fixes**
  - Enhanced error handling during binary download and version fetching for more reliable operation.
  - Improved installation process to avoid requiring elevated permissions by using cached binaries directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->