### PR TITLE
feat: configure env version rollout cli

### DIFF
--- a/cmd/ctrlc/root/api/upsert/policy/policy.go
+++ b/cmd/ctrlc/root/api/upsert/policy/policy.go
@@ -33,20 +33,21 @@ func parseEnvironmentVersionRollout(rollout string) (*api.InsertEnvironmentVersi
 
 	var parsedPositionGrowthFactor *float32
 	if selector["positionGrowthFactor"] != nil {
-		floatPositionGrowthFactor, ok := selector["positionGrowthFactor"].(float32)
+		float64PositionGrowthFactor, ok := selector["positionGrowthFactor"].(float64)
 		if !ok {
 			return nil, fmt.Errorf("invalid position growth factor: %v", selector["positionGrowthFactor"])
 		}
-		parsedPositionGrowthFactor = &floatPositionGrowthFactor
+		float32PositionGrowthFactor := float32(float64PositionGrowthFactor)
+		parsedPositionGrowthFactor = &float32PositionGrowthFactor
 	}
 
 	var parsedTimeScaleInterval float32
 	if selector["timeScaleInterval"] != nil {
-		floatTimeScaleInterval, ok := selector["timeScaleInterval"].(float32)
+		float64TimeScaleInterval, ok := selector["timeScaleInterval"].(float64)
 		if !ok {
 			return nil, fmt.Errorf("invalid time scale interval: %v", selector["timeScaleInterval"])
 		}
-		parsedTimeScaleInterval = floatTimeScaleInterval
+		parsedTimeScaleInterval = float32(float64TimeScaleInterval)
 	}
 
 	return &api.InsertEnvironmentVersionRollout{

--- a/cmd/ctrlc/root/apply/policy.go
+++ b/cmd/ctrlc/root/apply/policy.go
@@ -119,6 +119,21 @@ func createPolicyRequestBody(policy Policy) api.UpsertPolicyJSONRequestBody {
 		concurrency = &floatConcurrency
 	}
 
+	var environmentVersionRollout *api.InsertEnvironmentVersionRollout
+	if policy.EnvironmentVersionRollout != nil {
+		var rolloutType *api.InsertEnvironmentVersionRolloutRolloutType
+		if policy.EnvironmentVersionRollout.RolloutType != nil {
+			parsedRolloutType := *policy.EnvironmentVersionRollout.RolloutType
+			rolloutTypeCasted := api.InsertEnvironmentVersionRolloutRolloutType(parsedRolloutType)
+			rolloutType = &rolloutTypeCasted
+		}
+		environmentVersionRollout = &api.InsertEnvironmentVersionRollout{
+			PositionGrowthFactor: policy.EnvironmentVersionRollout.PositionGrowthFactor,
+			TimeScaleInterval:    policy.EnvironmentVersionRollout.TimeScaleInterval,
+			RolloutType:          rolloutType,
+		}
+	}
+
 	return api.UpsertPolicyJSONRequestBody{
 		Name:                      policy.Name,
 		Description:               policy.Description,
@@ -132,6 +147,7 @@ func createPolicyRequestBody(policy Policy) api.UpsertPolicyJSONRequestBody {
 		VersionUserApprovals:      &versionUserApprovals,
 		VersionRoleApprovals:      &versionRoleApprovals,
 		Concurrency:               concurrency,
+		EnvironmentVersionRollout: environmentVersionRollout,
 	}
 }
 

--- a/cmd/ctrlc/root/apply/types.go
+++ b/cmd/ctrlc/root/apply/types.go
@@ -129,6 +129,7 @@ type Policy struct {
 	VersionUserApprovals      []VersionUserApproval      `yaml:"versionUserApprovals,omitempty"`
 	VersionRoleApprovals      []VersionRoleApproval      `yaml:"versionRoleApprovals,omitempty"`
 	Concurrency               *int                       `yaml:"concurrency,omitempty"`
+	EnvironmentVersionRollout *EnvironmentVersionRollout `yaml:"environmentVersionRollout,omitempty"`
 }
 
 type PolicyTarget struct {
@@ -160,4 +161,10 @@ type VersionUserApproval struct {
 type VersionRoleApproval struct {
 	RoleId                 string  `yaml:"roleId"`
 	RequiredApprovalsCount float32 `yaml:"requiredApprovalsCount"`
+}
+
+type EnvironmentVersionRollout struct {
+	PositionGrowthFactor *float32 `yaml:"positionGrowthFactor,omitempty"`
+	TimeScaleInterval    float32  `yaml:"timeScaleInterval"`
+	RolloutType          *string  `yaml:"rolloutType,omitempty"`
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring environment version rollout strategies in policy creation and updates.
  - Introduced the ability to approve or reject deployment versions for specific environments.
  - Enabled locking and unlocking of release targets to control deployment flows.
  - Added new policy parameters, including rollout types and maximum retries.

- **Enhancements**
  - Extended policy configuration options to support advanced rollout and deployment controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->