### PR TITLE
chore: debug logging & env var for log level

### DIFF
--- a/cmd/ctrlc/root/root.go
+++ b/cmd/ctrlc/root/root.go
@@ -1,6 +1,8 @@
 package root
 
 import (
+	"os"
+
 	"github.com/MakeNowJust/heredoc/v2"
 
 	"github.com/charmbracelet/log"
@@ -43,7 +45,7 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Set the logging level (debug, info, warn, error)")
+	cmd.PersistentFlags().StringVar(&logLevel, "log-level", defaultOrEnv("info", "CTRLC_LOG_LEVEL"), "Set the logging level (debug, info, warn, error)")
 
 	cmd.AddCommand(agent.NewAgentCmd())
 	cmd.AddCommand(api.NewAPICmd())
@@ -55,4 +57,15 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(version.NewVersionCmd())
 
 	return cmd
+}
+
+func defaultOrEnv(defaultValue string, envVarName string) string {
+	if envVarName == "" {
+		return defaultValue
+	}
+	value, set := os.LookupEnv(envVarName)
+	if !set {
+		value = defaultValue
+	}
+	return value
 }

--- a/cmd/ctrlc/root/sync/aws/networks/networks.go
+++ b/cmd/ctrlc/root/sync/aws/networks/networks.go
@@ -234,6 +234,7 @@ func processNetwork(
 	consoleUrl := getVpcConsoleUrl(vpc, region)
 	metadata["ctrlplane/links"] = fmt.Sprintf("{ \"AWS Console\": \"%s\" }", consoleUrl)
 
+	log.Debug("Processed Network", "region", region, "name", vpcName, "id", *vpc.VpcId, "subnetCount", len(subnets))
 	return api.ResourceProviderResource{
 		Version:    "ctrlplane.dev/network/v1",
 		Kind:       "AmazonNetwork",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Log level can now be configured using the `CTRLC_LOG_LEVEL` environment variable for more flexible control over logging verbosity.

* **Improvements**
  * Enhanced debug logging during AWS network synchronization to capture region, VPC, and subnet metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->