### PR TITLE
Ctrlc apply http inputs

### DIFF
--- a/cmd/ctrlc/root/apply/cmd_test.go
+++ b/cmd/ctrlc/root/apply/cmd_test.go
@@ -440,3 +440,33 @@ func TestExpandGlob_ExcludeThenReinclude(t *testing.T) {
 		t.Error("test_app.yaml should be excluded")
 	}
 }
+
+func TestExpandGlob_URLInclude(t *testing.T) {
+	url := "https://example.com/config.yaml"
+
+	files, err := expandGlob([]string{url})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d: %v", len(files), files)
+	}
+
+	if files[0] != url {
+		t.Errorf("expected %s, got %s", url, files[0])
+	}
+}
+
+func TestExpandGlob_URLExclude(t *testing.T) {
+	url := "https://example.com/config.yaml"
+
+	_, err := expandGlob([]string{url, "!" + url})
+	if err == nil {
+		t.Fatal("expected error when URL is excluded")
+	}
+
+	if err.Error() != "no files matched patterns" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/cmd/ctrlc/root/apply/input.go
+++ b/cmd/ctrlc/root/apply/input.go
@@ -1,0 +1,63 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const defaultHTTPTimeout = 30 * time.Second
+
+func isHTTPURL(input string) bool {
+	parsed, err := url.Parse(input)
+	if err != nil {
+		return false
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return false
+	}
+	return parsed.Host != ""
+}
+
+// ParseInput reads a local file or HTTP(S) URL and returns parsed documents.
+func ParseInput(ctx context.Context, input string) ([]Document, error) {
+	if isHTTPURL(input) {
+		data, err := fetchHTTP(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		return ParseYAML(data)
+	}
+	return ParseFile(input)
+}
+
+func fetchHTTP(ctx context.Context, input string) ([]byte, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, input, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for %s: %w", input, err)
+	}
+
+	client := &http.Client{
+		Timeout: defaultHTTPTimeout,
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s: %w", input, err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("failed to fetch %s: status %s", input, response.Status)
+	}
+
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", input, err)
+	}
+
+	return data, nil
+}

--- a/cmd/ctrlc/root/apply/input_test.go
+++ b/cmd/ctrlc/root/apply/input_test.go
@@ -1,0 +1,53 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseInput_HTTP(t *testing.T) {
+	payload := `type: Resource
+name: test-resource
+identifier: test-id
+kind: Cluster
+version: v1
+`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, payload)
+	}))
+	defer server.Close()
+
+	documents, err := ParseInput(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(documents) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(documents))
+	}
+
+	if _, ok := documents[0].(*ResourceDocument); !ok {
+		t.Fatalf("expected ResourceDocument, got %T", documents[0])
+	}
+}
+
+func TestParseInput_HTTPStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	_, err := ParseInput(context.Background(), server.URL)
+	if err == nil {
+		t.Fatal("expected error for non-2xx response")
+	}
+
+	if !strings.Contains(err.Error(), "status 404") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Add support for HTTP(S) URLs as input to `ctrlc apply -f` to allow applying configurations directly from remote YAML files.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea34268b-3adf-48e8-b420-2c2fadf6322e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ea34268b-3adf-48e8-b420-2c2fadf6322e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces outbound HTTP fetching and URL handling in the CLI apply path, which can affect reliability and security expectations (timeouts, remote content, and error handling).
> 
> **Overview**
> `ctrlc apply -f` now accepts HTTP(S) URLs in addition to local file paths/globs, and the help text/examples were updated accordingly.
> 
> Input handling was extended with `ParseInput` to fetch remote YAML (30s timeout, error on non-2xx) and parse it like local files, while `expandGlob` was updated to treat URLs as explicit candidates with include/exclude semantics; new tests cover URL inclusion/exclusion and HTTP fetch/status error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faadf781444f048f7bf3a25647152152b2e607c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for applying YAML files from remote URLs in the apply command.
  * Include/exclude patterns now work with HTTP(S) URLs using last-match-wins semantics.

* **Improvements**
  * Enhanced URL input handling with a 30-second timeout for HTTP requests.
  * Updated error messaging for improved clarity during input processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->