### PR TITLE
fix: only error if config is directly provided

### DIFF
--- a/cmd/ctrlc/ctrlc.go
+++ b/cmd/ctrlc/ctrlc.go
@@ -45,10 +45,8 @@ func main() {
 }
 
 func initConfig() {
-	configProvided := false
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
-		configProvided = true
 	} else {
 		// Find home directory.
 		home, err := homedir.Dir()
@@ -64,7 +62,7 @@ func initConfig() {
 	}
 
 	if err := viper.ReadInConfig(); err != nil {
-		if configProvided {
+		if cfgFile != "" {
 			log.Error("Can't read config", "error", err)
 			os.Exit(1)
 		} else {

--- a/cmd/ctrlc/ctrlc.go
+++ b/cmd/ctrlc/ctrlc.go
@@ -45,8 +45,10 @@ func main() {
 }
 
 func initConfig() {
+	configProvided := false
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
+		configProvided = true
 	} else {
 		// Find home directory.
 		home, err := homedir.Dir()
@@ -62,7 +64,11 @@ func initConfig() {
 	}
 
 	if err := viper.ReadInConfig(); err != nil {
-		log.Error("Can't read config", "error", err)
-		os.Exit(1)
+		if configProvided {
+			log.Error("Can't read config", "error", err)
+			os.Exit(1)
+		} else {
+			log.Warn("Can't read config", "error", err)
+		}
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration file error handling: the app now logs a warning and continues when no config file is provided, instead of exiting. Supplying an explicit config file still yields a fatal error on read failures.
  * Reduces unexpected termination for users running without a config file, improving startup resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->