### PR TITLE
fix: Unify code responsible for upserting resources from `sync` subcommand

### DIFF
--- a/cmd/ctrlc/root/sync/aws/rds/rds.go
+++ b/cmd/ctrlc/root/sync/aws/rds/rds.go
@@ -515,36 +515,3 @@ func fetchParameterGroupDetails(ctx context.Context, rdsClient *rds.Client, para
 	}
 }
 
-// upsertToCtrlplane handles upserting resources to Ctrlplane
-func upsertToCtrlplane(ctx context.Context, resources []api.ResourceProviderResource, region, name *string) error {
-	if *name == "" {
-		*name = fmt.Sprintf("aws-rds-%s", *region)
-	}
-
-	apiURL := viper.GetString("url")
-	apiKey := viper.GetString("api-key")
-	workspaceId := viper.GetString("workspace")
-
-	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *name)
-	if err != nil {
-		return fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	// err = rp.AddResourceRelationshipRule(ctx, relationshipRules)
-	// if err != nil {
-	// 	log.Error("Failed to add resource relationship rule", "name", *name, "error", err)
-	// }
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
-	return nil
-}

--- a/cmd/ctrlc/root/sync/aws/rds/rds.go
+++ b/cmd/ctrlc/root/sync/aws/rds/rds.go
@@ -16,9 +16,7 @@ import (
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // NewSyncRDSCmd creates a new cobra command for syncing AWS RDS instances

--- a/cmd/ctrlc/root/sync/aws/rds/rds.go
+++ b/cmd/ctrlc/root/sync/aws/rds/rds.go
@@ -514,4 +514,3 @@ func fetchParameterGroupDetails(ctx context.Context, rdsClient *rds.Client, para
 		metadata["database/parameter-count"] = strconv.Itoa(paramCount)
 	}
 }
-

--- a/cmd/ctrlc/root/sync/aws/rds/rds.go
+++ b/cmd/ctrlc/root/sync/aws/rds/rds.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/cmd/ctrlc/root/sync/aws/common"
 	"github.com/ctrlplanedev/cli/internal/api"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
@@ -30,13 +31,13 @@ func NewSyncRDSCmd() *cobra.Command {
 		Short: "Sync Amazon Relational Database Service instances into Ctrlplane",
 		Example: heredoc.Doc(`
 			# Make sure AWS credentials are configured via environment variables or AWS CLI
-			
+
 			# Sync all RDS instances from a region
 			$ ctrlc sync aws rds --region us-west-2
-			
+
 			# Sync all RDS instances from multiple regions
 			$ ctrlc sync aws rds --region us-west-2 --region us-east-1
-			
+
 			# Sync all RDS instances from all regions
 			$ ctrlc sync aws rds
 		`),
@@ -138,7 +139,7 @@ func runSync(regions *[]string, name *string) func(cmd *cobra.Command, args []st
 		}
 
 		// Upsert resources to Ctrlplane
-		return upsertToCtrlplane(ctx, allResources, &providerRegion, name)
+		return ctrlp.UpsertResources(ctx, allResources, name)
 	}
 }
 

--- a/cmd/ctrlc/root/sync/azure/aks/aks.go
+++ b/cmd/ctrlc/root/sync/azure/aks/aks.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
@@ -99,7 +100,7 @@ func runSync(subscriptionID, name *string) func(cmd *cobra.Command, args []strin
 		}
 
 		// Upsert resources to Ctrlplane
-		return upsertToCtrlplane(ctx, resources, subscriptionID, name)
+		return ctrlp.UpsertResources(ctx, resources, name)
 	}
 }
 
@@ -435,36 +436,3 @@ func extractResourceGroupFromID(id string) string {
 // 		},
 // 	},
 // }
-
-func upsertToCtrlplane(ctx context.Context, resources []api.ResourceProviderResource, subscriptionID, name *string) error {
-	if *name == "" {
-		*name = fmt.Sprintf("azure-aks-%s", *subscriptionID)
-	}
-
-	apiURL := viper.GetString("url")
-	apiKey := viper.GetString("api-key")
-	workspaceId := viper.GetString("workspace")
-
-	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *name)
-	if err != nil {
-		return fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	// err = rp.AddResourceRelationshipRule(ctx, relationshipRules)
-	// if err != nil {
-	// 	log.Error("Failed to add resource relationship rule", "name", *name, "error", err)
-	// }
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
-	return nil
-}

--- a/cmd/ctrlc/root/sync/azure/aks/aks.go
+++ b/cmd/ctrlc/root/sync/azure/aks/aks.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/ctrlc/root/sync/azure/networks/networks.go
+++ b/cmd/ctrlc/root/sync/azure/networks/networks.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/ctrlc/root/sync/azure/networks/networks.go
+++ b/cmd/ctrlc/root/sync/azure/networks/networks.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/cmd/ctrlc/root/sync/azure/common"
 	"github.com/ctrlplanedev/cli/internal/api"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
@@ -95,7 +96,7 @@ func runSync(subscriptionID, name *string) func(cmd *cobra.Command, args []strin
 		}
 
 		// Upsert resources to Ctrlplane
-		return upsertToCtrlplane(ctx, resources, subscriptionID, name)
+		return ctrlp.UpsertResources(ctx, resources, name)
 	}
 }
 
@@ -403,32 +404,4 @@ func getSubnetState(subnet *armnetwork.Subnet) string {
 		return string(*subnet.Properties.ProvisioningState)
 	}
 	return ""
-}
-
-func upsertToCtrlplane(ctx context.Context, resources []api.ResourceProviderResource, subscriptionID, name *string) error {
-	if *name == "" {
-		*name = fmt.Sprintf("azure-networks-%s", *subscriptionID)
-	}
-
-	apiURL := viper.GetString("url")
-	apiKey := viper.GetString("api-key")
-	workspaceId := viper.GetString("workspace")
-
-	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *name)
-	if err != nil {
-		return fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
-	return nil
 }

--- a/cmd/ctrlc/root/sync/github/pullrequests.go
+++ b/cmd/ctrlc/root/sync/github/pullrequests.go
@@ -13,10 +13,8 @@ import (
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/google/go-github/v57/github"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 )
 

--- a/cmd/ctrlc/root/sync/google/bigtable/bigtable.go
+++ b/cmd/ctrlc/root/sync/google/bigtable/bigtable.go
@@ -13,9 +13,7 @@ import (
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/api/bigtableadmin/v2"
 )
 

--- a/cmd/ctrlc/root/sync/google/bigtable/bigtable.go
+++ b/cmd/ctrlc/root/sync/google/bigtable/bigtable.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
@@ -87,8 +88,13 @@ func runSync(project, name *string) func(cmd *cobra.Command, args []string) erro
 			return err
 		}
 
+		// Set default provider name if not provided
+		if *name == "" {
+			*name = fmt.Sprintf("google-bigtable-project-%s", *project)
+		}
+
 		// Upsert resources to Ctrlplane
-		return upsertToCtrlplane(ctx, resources, project, name)
+		return ctrlp.UpsertResources(ctx, resources, name)
 	}
 }
 
@@ -289,34 +295,5 @@ func processTables(adminClient *bigtableadmin.Service, instance *bigtableadmin.I
 		metadata["database/size-gb"] = strconv.FormatFloat(float64(totalSizeBytes)/1024/1024/1024, 'f', 0, 64)
 	}
 
-	return nil
-}
-
-// upsertToCtrlplane handles upserting resources to Ctrlplane
-func upsertToCtrlplane(ctx context.Context, resources []api.ResourceProviderResource, project, name *string) error {
-	if *name == "" {
-		*name = fmt.Sprintf("google-bigtable-project-%s", *project)
-	}
-
-	apiURL := viper.GetString("url")
-	apiKey := viper.GetString("api-key")
-	workspaceId := viper.GetString("workspace")
-
-	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *name)
-	if err != nil {
-		return fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
 	return nil
 }

--- a/cmd/ctrlc/root/sync/google/buckets/buckets.go
+++ b/cmd/ctrlc/root/sync/google/buckets/buckets.go
@@ -12,9 +12,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/api/storage/v1"
 )
 

--- a/cmd/ctrlc/root/sync/google/buckets/buckets.go
+++ b/cmd/ctrlc/root/sync/google/buckets/buckets.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -78,8 +79,13 @@ func runSync(project, name *string) func(cmd *cobra.Command, args []string) erro
 			return err
 		}
 
+		// Set default provider name if not provided
+		if *name == "" {
+			*name = fmt.Sprintf("google-buckets-project-%s", *project)
+		}
+
 		// Upsert resources to Ctrlplane
-		return upsertToCtrlplane(ctx, resources, project, name)
+		return ctrlp.UpsertResources(ctx, resources, name)
 	}
 }
 
@@ -457,33 +463,4 @@ func processBucketStats(storageClient *storage.Service, bucket *storage.Bucket, 
 			metadata["storage/size-mb"] = "0"
 		}
 	}
-}
-
-// upsertToCtrlplane handles upserting resources to Ctrlplane
-func upsertToCtrlplane(ctx context.Context, resources []api.ResourceProviderResource, project, name *string) error {
-	if *name == "" {
-		*name = fmt.Sprintf("google-buckets-project-%s", *project)
-	}
-
-	apiURL := viper.GetString("url")
-	apiKey := viper.GetString("api-key")
-	workspaceId := viper.GetString("workspace")
-
-	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *name)
-	if err != nil {
-		return fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
-	return nil
 }

--- a/cmd/ctrlc/root/sync/google/cloudrun/cloudrun.go
+++ b/cmd/ctrlc/root/sync/google/cloudrun/cloudrun.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
 	"github.com/ctrlplanedev/cli/internal/cliutil"
-	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/ctrlc/root/sync/google/cloudrun/cloudrun.go
+++ b/cmd/ctrlc/root/sync/google/cloudrun/cloudrun.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
 	"github.com/ctrlplanedev/cli/internal/cliutil"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -102,34 +103,6 @@ func processService(service *run.Service) api.ResourceProviderResource {
 	return resource
 }
 
-func upsertToCtrlplane(ctx context.Context, resources []api.ResourceProviderResource, project *string, providerName *string) (*http.Response, error) {
-	if *providerName == "" {
-		*providerName = fmt.Sprintf("google-cloudrun-%s", *project)
-	}
-
-	apiURL := viper.GetString("url")
-	apiKey := viper.GetString("api-key")
-	workspaceId := viper.GetString("workspace")
-
-	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	log.Info("Upserting resource provider", "name", *providerName)
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *providerName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return nil, fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
-	return upsertResp, nil
-}
 
 func runSync(project, providerName *string, regions *[]string) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
@@ -153,10 +126,34 @@ func runSync(project, providerName *string, regions *[]string) func(cmd *cobra.C
 			allResources = append(allResources, resource)
 		}
 
-		upsertResp, err := upsertToCtrlplane(ctx, allResources, project, providerName)
+		// Set default provider name if not provided
+		if *providerName == "" {
+			*providerName = fmt.Sprintf("google-cloudrun-%s", *project)
+		}
+
+		// Upsert resources to Ctrlplane using common logic
+		// We need to get the response for HandleResponseOutput, so we inline part of the logic
+		apiURL := viper.GetString("url")
+		apiKey := viper.GetString("api-key")
+		workspaceId := viper.GetString("workspace")
+
+		ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
+		if err != nil {
+			return fmt.Errorf("failed to create API client: %w", err)
+		}
+
+		log.Info("Upserting resource provider", "name", *providerName)
+		rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *providerName)
+		if err != nil {
+			return fmt.Errorf("failed to create resource provider: %w", err)
+		}
+
+		upsertResp, err := rp.UpsertResource(ctx, allResources)
 		if err != nil {
 			return fmt.Errorf("failed to upsert Cloud Run services: %w", err)
 		}
+
+		log.Info("Response from upserting resources", "status", upsertResp.Status)
 		fmt.Println(upsertResp)
 
 		return cliutil.HandleResponseOutput(cmd, upsertResp)

--- a/cmd/ctrlc/root/sync/google/cloudrun/cloudrun.go
+++ b/cmd/ctrlc/root/sync/google/cloudrun/cloudrun.go
@@ -8,10 +8,8 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
-	"github.com/ctrlplanedev/cli/internal/cliutil"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/api/run/v1"
 )
 
@@ -128,32 +126,8 @@ func runSync(project, providerName *string, regions *[]string) func(cmd *cobra.C
 			*providerName = fmt.Sprintf("google-cloudrun-%s", *project)
 		}
 
-		// Upsert resources to Ctrlplane using common logic
-		// We need to get the response for HandleResponseOutput, so we inline part of the logic
-		apiURL := viper.GetString("url")
-		apiKey := viper.GetString("api-key")
-		workspaceId := viper.GetString("workspace")
-
-		ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-		if err != nil {
-			return fmt.Errorf("failed to create API client: %w", err)
-		}
-
-		log.Info("Upserting resource provider", "name", *providerName)
-		rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *providerName)
-		if err != nil {
-			return fmt.Errorf("failed to create resource provider: %w", err)
-		}
-
-		upsertResp, err := rp.UpsertResource(ctx, allResources)
-		if err != nil {
-			return fmt.Errorf("failed to upsert Cloud Run services: %w", err)
-		}
-
-		log.Info("Response from upserting resources", "status", upsertResp.Status)
-		fmt.Println(upsertResp)
-
-		return cliutil.HandleResponseOutput(cmd, upsertResp)
+		// Upsert resources to Ctrlplane
+		return ctrlp.UpsertResources(ctx, allResources, providerName)
 	}
 }
 

--- a/cmd/ctrlc/root/sync/google/cloudrun/cloudrun.go
+++ b/cmd/ctrlc/root/sync/google/cloudrun/cloudrun.go
@@ -103,7 +103,6 @@ func processService(service *run.Service) api.ResourceProviderResource {
 	return resource
 }
 
-
 func runSync(project, providerName *string, regions *[]string) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		log.Info("Syncing Cloud Run services into Ctrlplane", "project", *project)

--- a/cmd/ctrlc/root/sync/google/cloudsql/cloudsql.go
+++ b/cmd/ctrlc/root/sync/google/cloudsql/cloudsql.go
@@ -12,9 +12,7 @@ import (
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/api/sqladmin/v1"
 )
 

--- a/cmd/ctrlc/root/sync/google/gke/gke.go
+++ b/cmd/ctrlc/root/sync/google/gke/gke.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
@@ -73,8 +74,13 @@ func runSync(project, name *string) func(cmd *cobra.Command, args []string) erro
 			return err
 		}
 
+		// Set default provider name if not provided
+		if *name == "" {
+			*name = fmt.Sprintf("google-gke-project-%s", *project)
+		}
+
 		// Upsert resources to Ctrlplane
-		return upsertToCtrlplane(ctx, resources, project, name)
+		return ctrlp.UpsertResources(ctx, resources, name)
 	}
 }
 
@@ -401,39 +407,3 @@ func getResourceName(fullPath string) string {
 // 		},
 // 	},
 // }
-
-// upsertToCtrlplane handles upserting resources to Ctrlplane
-func upsertToCtrlplane(ctx context.Context, resources []api.ResourceProviderResource, project, name *string) error {
-	if *name == "" {
-		*name = fmt.Sprintf("google-gke-project-%s", *project)
-	}
-
-	apiURL := viper.GetString("url")
-	apiKey := viper.GetString("api-key")
-	workspace := viper.GetString("workspace")
-
-	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	workspaceId := ctrlplaneClient.GetWorkspaceID(ctx, workspace)
-
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId.String(), *name)
-	if err != nil {
-		return fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	// err = rp.AddResourceRelationshipRule(ctx, relationshipRules)
-	// if err != nil {
-	// 	log.Error("Failed to add resource relationship rule", "name", *name, "error", err)
-	// }
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
-	return nil
-}

--- a/cmd/ctrlc/root/sync/google/gke/gke.go
+++ b/cmd/ctrlc/root/sync/google/gke/gke.go
@@ -13,9 +13,7 @@ import (
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/api/container/v1"
 )
 

--- a/cmd/ctrlc/root/sync/google/networks/networks.go
+++ b/cmd/ctrlc/root/sync/google/networks/networks.go
@@ -11,9 +11,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/api/compute/v1"
 )
 

--- a/cmd/ctrlc/root/sync/google/networks/networks.go
+++ b/cmd/ctrlc/root/sync/google/networks/networks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -94,8 +95,13 @@ func runSync(project, name *string) func(cmd *cobra.Command, args []string) erro
 		resources = append(resources, firewallResources...)
 		resources = append(resources, forwardingRuleResources...)
 
+		// Set default provider name if not provided
+		if *name == "" {
+			*name = fmt.Sprintf("google-networks-project-%s", *project)
+		}
+
 		// Upsert resources to Ctrlplane
-		return upsertToCtrlplane(ctx, resources, project, name)
+		return ctrlp.UpsertResources(ctx, resources, name)
 	}
 }
 
@@ -761,33 +767,4 @@ func getResourceName(fullPath string) string {
 	}
 	parts := strings.Split(fullPath, "/")
 	return parts[len(parts)-1]
-}
-
-// upsertToCtrlplane handles upserting resources to Ctrlplane
-func upsertToCtrlplane(ctx context.Context, resources []api.ResourceProviderResource, project, name *string) error {
-	if *name == "" {
-		*name = fmt.Sprintf("google-networks-project-%s", *project)
-	}
-
-	apiURL := viper.GetString("url")
-	apiKey := viper.GetString("api-key")
-	workspaceId := viper.GetString("workspace")
-
-	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *name)
-	if err != nil {
-		return fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
-	return nil
 }

--- a/cmd/ctrlc/root/sync/google/redis/redis.go
+++ b/cmd/ctrlc/root/sync/google/redis/redis.go
@@ -12,9 +12,7 @@ import (
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/api/redis/v1"
 )
 

--- a/cmd/ctrlc/root/sync/google/redis/redis.go
+++ b/cmd/ctrlc/root/sync/google/redis/redis.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/internal/kinds"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
@@ -72,8 +73,13 @@ func runSync(project, name *string) func(cmd *cobra.Command, args []string) erro
 			return err
 		}
 
+		// Set default provider name if not provided
+		if *name == "" {
+			*name = fmt.Sprintf("google-redis-project-%s", *project)
+		}
+
 		// Upsert resources to Ctrlplane
-		return upsertToCtrlplane(ctx, resources, project, name)
+		return ctrlp.UpsertResources(ctx, resources, name)
 	}
 }
 
@@ -287,33 +293,4 @@ func getInstanceName(fullName string) string {
 		return parts[5]
 	}
 	return fullName
-}
-
-// upsertToCtrlplane handles upserting resources to Ctrlplane
-func upsertToCtrlplane(ctx context.Context, resources []api.ResourceProviderResource, project, name *string) error {
-	if *name == "" {
-		*name = fmt.Sprintf("google-redis-project-%s", *project)
-	}
-
-	apiURL := viper.GetString("url")
-	apiKey := viper.GetString("api-key")
-	workspaceId := viper.GetString("workspace")
-
-	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *name)
-	if err != nil {
-		return fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
-	return nil
 }

--- a/cmd/ctrlc/root/sync/google/secrets/secrets.go
+++ b/cmd/ctrlc/root/sync/google/secrets/secrets.go
@@ -11,9 +11,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/api/secretmanager/v1"
 )
 

--- a/cmd/ctrlc/root/sync/google/secrets/secrets.go
+++ b/cmd/ctrlc/root/sync/google/secrets/secrets.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -71,8 +72,13 @@ func runSync(project, name *string) func(cmd *cobra.Command, args []string) erro
 			return err
 		}
 
+		// Set default provider name if not provided
+		if *name == "" {
+			*name = fmt.Sprintf("google-secrets-project-%s", *project)
+		}
+
 		// Upsert resources to Ctrlplane
-		return upsertToCtrlplane(ctx, resources, project, name)
+		return ctrlp.UpsertResources(ctx, resources, name)
 	}
 }
 
@@ -284,33 +290,4 @@ func getResourceName(fullPath string) string {
 	}
 	parts := strings.Split(fullPath, "/")
 	return parts[len(parts)-1]
-}
-
-// upsertToCtrlplane handles upserting resources to Ctrlplane
-func upsertToCtrlplane(ctx context.Context, resources []api.ResourceProviderResource, project, name *string) error {
-	if *name == "" {
-		*name = fmt.Sprintf("google-secrets-project-%s", *project)
-	}
-
-	apiURL := viper.GetString("url")
-	apiKey := viper.GetString("api-key")
-	workspaceId := viper.GetString("workspace")
-
-	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *name)
-	if err != nil {
-		return fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
-	return nil
 }

--- a/cmd/ctrlc/root/sync/google/vms/vms.go
+++ b/cmd/ctrlc/root/sync/google/vms/vms.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -71,8 +72,13 @@ func runSync(project, name *string) func(cmd *cobra.Command, args []string) erro
 			return err
 		}
 
+		// Set default provider name if not provided
+		if *name == "" {
+			*name = fmt.Sprintf("google-vms-project-%s", *project)
+		}
+
 		// Upsert resources to Ctrlplane
-		return upsertToCtrlplane(ctx, resources, project, name)
+		return ctrlp.UpsertResources(ctx, resources, name)
 	}
 }
 
@@ -393,33 +399,4 @@ func getResourceName(fullPath string) string {
 	}
 	parts := strings.Split(fullPath, "/")
 	return parts[len(parts)-1]
-}
-
-// upsertToCtrlplane handles upserting resources to Ctrlplane
-func upsertToCtrlplane(ctx context.Context, resources []api.ResourceProviderResource, project, name *string) error {
-	if *name == "" {
-		*name = fmt.Sprintf("google-vms-project-%s", *project)
-	}
-
-	apiURL := viper.GetString("url")
-	apiKey := viper.GetString("api-key")
-	workspaceId := viper.GetString("workspace")
-
-	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *name)
-	if err != nil {
-		return fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
-	return nil
 }

--- a/cmd/ctrlc/root/sync/google/vms/vms.go
+++ b/cmd/ctrlc/root/sync/google/vms/vms.go
@@ -11,9 +11,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/api/compute/v1"
 )
 

--- a/cmd/ctrlc/root/sync/kubernetes/kubernetes.go
+++ b/cmd/ctrlc/root/sync/kubernetes/kubernetes.go
@@ -160,27 +160,3 @@ func NewSyncKubernetesCmd() *cobra.Command {
 	return cmd
 }
 
-// upsertToCtrlplane handles upserting resources to Ctrlplane
-func upsertToCtrlplane(ctrlplaneClient *api.ClientWithResponses, resources []api.ResourceProviderResource, clusterIdentifier string, clusterName string, providerName string) error {
-	ctx := context.Background()
-	workspaceId := viper.GetString("workspace")
-
-	if providerName == "" {
-		providerName = fmt.Sprintf("kubernetes-cluster-%s", clusterName)
-	}
-
-	log.Info("Using provider name", "provider", providerName)
-
-	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, providerName)
-	if err != nil {
-		return fmt.Errorf("failed to create resource provider: %w", err)
-	}
-
-	upsertResp, err := rp.UpsertResource(ctx, resources)
-	if err != nil {
-		return fmt.Errorf("failed to upsert resources: %w", err)
-	}
-
-	log.Info("Response from upserting resources", "status", upsertResp.Status)
-	return nil
-}

--- a/cmd/ctrlc/root/sync/kubernetes/kubernetes.go
+++ b/cmd/ctrlc/root/sync/kubernetes/kubernetes.go
@@ -9,7 +9,6 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
 	ctrlp "github.com/ctrlplanedev/cli/internal/common"
-	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	appsv1 "k8s.io/api/apps/v1"

--- a/cmd/ctrlc/root/sync/kubernetes/kubernetes.go
+++ b/cmd/ctrlc/root/sync/kubernetes/kubernetes.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/charmbracelet/log"
 	"github.com/ctrlplanedev/cli/internal/api"
+	ctrlp "github.com/ctrlplanedev/cli/internal/common"
 	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -78,6 +79,7 @@ func NewSyncKubernetesCmd() *cobra.Command {
 			$ ctrlc sync kubernetes --cluster-identifier 1234567890 --cluster-name my-cluster
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
 			log.Info("Syncing Kubernetes resources on a cluster")
 			if clusterIdentifier == "" {
 				clusterIdentifier = viper.GetString("cluster-identifier")
@@ -99,7 +101,6 @@ func NewSyncKubernetesCmd() *cobra.Command {
 				return fmt.Errorf("failed to create API client: %w", err)
 			}
 
-			ctx := context.Background()
 			clusterResource, _ := ctrlplaneClient.GetResourceByIdentifierWithResponse(ctx, workspaceId, clusterIdentifier)
 			if clusterResource.JSON200 != nil {
 				clusterName = clusterResource.JSON200.Name
@@ -149,7 +150,7 @@ func NewSyncKubernetesCmd() *cobra.Command {
 				}
 			}
 
-			return upsertToCtrlplane(ctrlplaneClient, resources, clusterIdentifier, clusterName, providerName)
+			return ctrlp.UpsertResources(ctx, resources, &providerName)
 		},
 	}
 	cmd.Flags().StringVarP(&providerName, "provider", "p", "", "Name of the resource provider")

--- a/cmd/ctrlc/root/sync/kubernetes/kubernetes.go
+++ b/cmd/ctrlc/root/sync/kubernetes/kubernetes.go
@@ -159,4 +159,3 @@ func NewSyncKubernetesCmd() *cobra.Command {
 
 	return cmd
 }
-

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -11,7 +11,7 @@ import (
 )
 
 func UpsertResources(ctx context.Context, resources []api.ResourceProviderResource, name *string) error {
-	if *name == "" {
+	if name == nil || *name == "" {
 		return fmt.Errorf("name is unset, invalid usage.")
 	}
 

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -12,7 +12,7 @@ import (
 
 func UpsertResources(ctx context.Context, resources []api.ResourceProviderResource, name *string) error {
 	if name == nil || *name == "" {
-		return fmt.Errorf("name is unset, invalid usage.")
+		return fmt.Errorf("name is unset, invalid usage")
 	}
 
 	apiURL := viper.GetString("url")

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -1,0 +1,39 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/log"
+	"github.com/ctrlplanedev/cli/internal/api"
+	"github.com/ctrlplanedev/cli/pkg/resourceprovider"
+	"github.com/spf13/viper"
+)
+
+func UpsertResources(ctx context.Context, resources []api.ResourceProviderResource, name *string) error {
+	if *name == "" {
+		return fmt.Errorf("name is unset, invalid usage.")
+	}
+
+	apiURL := viper.GetString("url")
+	apiKey := viper.GetString("api-key")
+	workspaceId := viper.GetString("workspace")
+
+	ctrlplaneClient, err := api.NewAPIKeyClientWithResponses(apiURL, apiKey)
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	rp, err := resourceprovider.New(ctrlplaneClient, workspaceId, *name)
+	if err != nil {
+		return fmt.Errorf("failed to create resource provider: %w", err)
+	}
+
+	upsertResp, err := rp.UpsertResource(ctx, resources)
+	if err != nil {
+		return fmt.Errorf("failed to upsert resources: %w", err)
+	}
+
+	log.Info("Response from upserting resources", "status", upsertResp.Status)
+	return nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated resource upsert logic into a centralized shared utility used by all cloud provider sync commands (AWS, Azure, Google, GitHub, Kubernetes).
  * Removed duplicated in-file upsert helpers; sync flows now delegate to the shared upsert utility.
  * Commands now ensure a non-empty provider name (generate a default when none supplied) before upserting resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->