### PR TITLE
chore: nix flake + package + dev shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ test.bash
 .idea
 .vscode
 *.test.yaml
+.history
+result
+result-*
 
 switch.sh

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "Ctrlplane CLI (ctrlc)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        version =
+          if (self ? rev)
+          then self.shortRev
+          else "dev";
+      in
+      {
+        packages = {
+          ctrlc = pkgs.buildGoModule {
+            pname = "ctrlc";
+            inherit version;
+            src = ./.;
+
+            vendorHash = "sha256-n/yfb1cCeQmfECyKsjsdsEYJM/rTip3d5mzMHXOHEDY=";
+
+            subPackages = [ "cmd/ctrlc" ];
+
+            env.CGO_ENABLED = "0";
+
+            tags = [ "containers_image_openpgp" ];
+
+            ldflags = [
+              "-s" "-w"
+              "-X github.com/ctrlplanedev/cli/cmd/ctrlc/root/version.Version=${version}"
+              "-X github.com/ctrlplanedev/cli/cmd/ctrlc/root/version.GitCommit=${self.rev or "dirty"}"
+              "-X github.com/ctrlplanedev/cli/cmd/ctrlc/root/version.BuildDate=1970-01-01T00:00:00Z"
+            ];
+
+            meta = with pkgs.lib; {
+              description = "CLI for Ctrlplane - manage deployments, resources, and jobs";
+              homepage = "https://github.com/ctrlplanedev/cli";
+              mainProgram = "ctrlc";
+            };
+          };
+
+          default = self.packages.${system}.ctrlc;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            go_1_24
+            golangci-lint
+            goreleaser
+          ];
+        };
+      });
+}


### PR DESCRIPTION
# Background

Adding an alternate mechanism for installing `ctrlc` using nix.

## What's Changed

 - nix flake with package
   - ability to install `ctrlc` using nix
 - nix dev shell
   - simply running `nix develop` will install dependencies locally and let you run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Nix Flake configuration for the Ctrlplane CLI, enabling standardized and reproducible development environments
  * Updated repository ignore patterns to maintain cleaner version control state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->