### PR TITLE
fix: resource variableSync failure

### DIFF
--- a/internal/api/providers/resource.go
+++ b/internal/api/providers/resource.go
@@ -171,7 +171,7 @@ func (r *ResourceItemSpec) syncVariables(ctx Context) error {
 			if varsResp.StatusCode() == 404 {
 				return fmt.Errorf("resource not found yet, retrying")
 			}
-			if varsResp.StatusCode() != 204 {
+			if varsResp.StatusCode() != 202 {
 				return retry.Unrecoverable(fmt.Errorf("failed to update resource variables: %s", string(varsResp.Body)))
 			}
 			return nil


### PR DESCRIPTION
Match the openapi spec.

Example error:
```bash
✗ Resource/example-amazon: update failed: All attempts fail:
#1: failed to update resource variables: {"id":"d8c530a2-9da8-40e6-91bc-ebc5323befe0","message":"Resource variables update requested"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of resource variable update responses to ensure proper success and error recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->