### PR TITLE
chore: surface error if getProviderId called on resource without proivder

### DIFF
--- a/internal/api/providers/resource.go
+++ b/internal/api/providers/resource.go
@@ -130,7 +130,7 @@ func (r *ResourceItemSpec) upsert(ctx Context) error {
 func (r *ResourceItemSpec) getProviderID(ctx Context) (string, error) {
 	providerName := r.Provider
 	if providerName == "" {
-		providerName = "ctrlc-apply"
+		return "", fmt.Errorf("resource has no provider")
 	}
 
 	providerResp, err := ctx.APIClient().GetResourceProviderByNameWithResponse(ctx.Ctx(), ctx.WorkspaceIDValue(), providerName)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource upsert operations now fail with a clear error message when a provider is not declared, instead of silently proceeding with a default value. This improvement helps catch configuration issues earlier and provides better visibility into resource setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->